### PR TITLE
add support for passing opts to new client

### DIFF
--- a/lib/resty/aws_s3/client.lua
+++ b/lib/resty/aws_s3/client.lua
@@ -11,16 +11,17 @@ local _M = {}
 local mt = { __index = _M }
 
 
-function _M.new(access_key, secret_key, endpoint, port, client_opts)
+function _M.new(access_key, secret_key, endpoint, port, client_opts, opts)
     if type(endpoint) ~= 'string' then
         return nil, 'InvalidArgument', string.format(
                 'invalid endpoint: %s is not a string', tostring(endpoint))
     end
 
     local signer, err, errmsg
+    opts = opts or {}
 
     if access_key ~= nil and secret_key ~= nil then
-        signer, err, errmsg = aws_singer.new(access_key, secret_key)
+        signer, err, errmsg = aws_singer.new(access_key, secret_key, opts)
         if err ~= nil then
             return nil, err, errmsg
         end


### PR DESCRIPTION
We need to be able to specify a region in `signer` to access s3 buckets in AWS  for regions other than `us-east-1` as specified [here](https://github.com/bsc-s2/lua-resty-awsauth/blob/8a71b3bfeddffff49157600859e470b7b9c2e7ff/lib/resty/awsauth/aws_signer.lua#L38).

I added the `opts` to allow us pass the region and any other options we want for the `signer`